### PR TITLE
Add declarations for attributes and varyings

### DIFF
--- a/src/iglu/glsl.cljc
+++ b/src/iglu/glsl.cljc
@@ -127,6 +127,12 @@
 (defn ->uniform [[name type]]
   (str "uniform " (parse-type type) " " name))
 
+(defn ->attribute [[name type]]
+  (str "attribute " (parse-type type) " " name))
+
+(defn ->varying [[name type]]
+  (str "varying " (parse-type type) " " name))
+
 (defn ->out [[name type]]
   (when type
     (str "out " (parse-type type) " " name)))
@@ -186,17 +192,18 @@
              :else 0)))))
 
 (defn iglu->glsl [{:keys [version precision
-                          uniforms inputs outputs
+                          uniforms attributes varyings inputs outputs
                           signatures functions fn-deps]
                    :as shader}]
   (->> (cond-> []
                version (conj (str "#version " version))
                precision (conj (str "precision " precision))
                uniforms (into (mapv ->uniform uniforms))
+               attributes (into (mapv ->attribute attributes))
+               varyings (into (mapv ->varying varyings))
                inputs (into (mapv ->in inputs))
                outputs (into (mapv ->out outputs))
                functions (into (mapv (partial ->function signatures)
                                  (sort-fns functions fn-deps))))
        (reduce (partial stringify 0) [])
        (str/join \newline)))
-

--- a/src/iglu/parse.cljc
+++ b/src/iglu/parse.cljc
@@ -10,6 +10,8 @@
 (s/def ::version string?)
 (s/def ::precision string?)
 (s/def ::uniforms ::declarations)
+(s/def ::attributes ::declarations)
+(s/def ::varyings ::declarations)
 (s/def ::inputs ::declarations)
 (s/def ::outputs ::declarations)
 
@@ -50,6 +52,8 @@
 (s/def ::shader (s/keys :opt-un [::version
                                  ::precision
                                  ::uniforms
+                                 ::attributes
+                                 ::varyings
                                  ::inputs
                                  ::outputs
                                  ::signatures


### PR DESCRIPTION
Hi @oakes, I really like what you've done here. Very nice being able to declaratively build shader programs in lisp syntax. I started using this with [regl-project/regl](https://github.com/regl-project/regl) and I had a need for attribute and varying state variables, so I added them to the library. 

I was doing this by string-appending at first, but the code for adding the glsl state vars looked pretty simple and I got it working with my [test case](https://github.com/jjsullivan5196/stegocljs/blob/gl-experiments/src/stego/gl/image.cljs). Figured this might be useful to someone else, so feel free to pull if you like. I agree to dedicate this as a contribution in the public domain. Thanks for your work!